### PR TITLE
./configure switch for custom base directory

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1,8 +1,8 @@
 PHP_ARG_WITH(phpwkhtmltox, [for libwkhtmltox support],
-[  --with-phpwkhtmltox     Include libwkhtmltox support])
+[  --with-phpwkhtmltox=[DIR]     Include libwkhtmltox support])
 
 if test "$PHP_PHPWKHTMLTOX" != "no"; then
-    for i in /usr /usr/local /opt; do
+    for i in $PHP_PHPWKHTMLTOX /usr /usr/local /opt; do
         if test -f $i/include/wkhtmltox/pdf.h; then
             WKHTMLTOX_LIB_DIR=$i/lib
             WKHTMLTOX_INC_DIR=$i/include


### PR DESCRIPTION
In my fork I added the possibility to pass a custom base directory for libwkhtmltox to the `--with-phpwkhtmltox` switch of `./configure`. I'd love to see this pulled into the head branch.
