### PR TITLE
Added Support for PHP 5.4.x

### DIFF
--- a/phpwkhtmltox.c
+++ b/phpwkhtmltox.c
@@ -11,7 +11,7 @@
 
 ZEND_DECLARE_MODULE_GLOBALS(phpwkhtmltox)
 
-static function_entry phpwkhtmltox_functions[] = {
+static zend_function_entry phpwkhtmltox_functions[] = {
     PHP_FE(wkhtmltox_convert, NULL)
     {NULL, NULL, NULL}
 };


### PR DESCRIPTION
PHP 5.4 requires the use of zend_function_entry, rather than the deprecated alias function_entry.
